### PR TITLE
Change react components to class properties

### DIFF
--- a/open-widget-framework/package.json
+++ b/open-widget-framework/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
     "chai": "^4.2.0",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",

--- a/open-widget-framework/src/defaults.js
+++ b/open-widget-framework/src/defaults.js
@@ -53,18 +53,10 @@ class _defaultListWrapper extends Component {
    *      passes props to the FormWrapper
    *    renderList(props): renders the list of widgets, passing props to each widgetWrapper
    */
-  constructor(props) {
-    super(props)
-    this.state = {
-      editMode: false,
-      addWidgetForm: false,
-      editWidgetForm: null,
-    }
-    this.renderAddWidgetButton = this.renderAddWidgetButton.bind(this)
-    this.closeForm = this.closeForm.bind(this)
-    this.toggleEditMode = this.toggleEditMode.bind(this)
-    this.editWidget = this.editWidget.bind(this)
-    this.addWidget = this.addWidget.bind(this)
+  state = {
+    editMode: false,
+    addWidgetForm: false,
+    editWidgetForm: null,
   }
 
   addWidget = () => {
@@ -78,7 +70,7 @@ class _defaultListWrapper extends Component {
     })
   }
 
-  renderAddWidgetButton() {
+  renderAddWidgetButton = () => {
     /**
      * renderAddWidgetButton creates a button to add a new widget
      */
@@ -89,7 +81,7 @@ class _defaultListWrapper extends Component {
     )
   }
 
-  closeForm() {
+  closeForm = () => {
     /**
      * closeForm sets the state so that no forms are rendered
      */
@@ -99,7 +91,7 @@ class _defaultListWrapper extends Component {
     })
   }
 
-  toggleEditMode() {
+  toggleEditMode = () => {
     /**
      * toggleEditMode toggles the value of editMode
      */
@@ -108,7 +100,7 @@ class _defaultListWrapper extends Component {
     this.closeForm()
   }
 
-  editWidget(widgetId) {
+  editWidget = (widgetId) => {
     /**
      * editWidget sets the state so that an edit widget form is rendered
      *
@@ -192,16 +184,8 @@ class _defaultWidgetWrapper extends Component {
    *    editWidget(): renders an edit widget form for the widget
    *    editMode: a boolean indicating whether the edit bar should be rendered or not
    */
-  constructor(props) {
-    super(props)
-    this.renderEditBar = this.renderEditBar.bind(this)
-    this.moveWidgetUp = this.moveWidgetUp.bind(this)
-    this.moveWidgetDown = this.moveWidgetDown.bind(this)
-    this.editWidget = this.editWidget.bind(this)
-    this.deleteWidget = this.deleteWidget.bind(this)
-  }
 
-  moveWidgetUp() {
+  moveWidgetUp = () => {
     /**
      * moveWidgetUp moves the widget up one position. It's an onClick function for the edit bar
      */
@@ -209,7 +193,7 @@ class _defaultWidgetWrapper extends Component {
     moveWidget(position - 1)
   }
 
-  moveWidgetDown() {
+  moveWidgetDown = () => {
     /**
      * moveWidgetDown moves the widget down one position. It's an onClick function for the edit bar
      */
@@ -217,7 +201,7 @@ class _defaultWidgetWrapper extends Component {
     moveWidget(position + 1)
   }
 
-  editWidget() {
+  editWidget = () => {
     /**
      * editWidget activates editMode for the widget. It's an onClick function for the edit bar
      */
@@ -225,7 +209,7 @@ class _defaultWidgetWrapper extends Component {
     editWidget(id)
   }
 
-  deleteWidget() {
+  deleteWidget = () => {
     /**
      * deleteWidget deletes the widget. It's an onClick function for the edit bar
      */
@@ -233,7 +217,7 @@ class _defaultWidgetWrapper extends Component {
     deleteWidget()
   }
 
-  renderEditBar() {
+  renderEditBar = () => {
     /**
      * renderEditBar renders the edit bar for the widget
      */

--- a/open-widget-framework/src/widget_form.js
+++ b/open-widget-framework/src/widget_form.js
@@ -21,14 +21,10 @@ class EditWidgetForm extends Component {
    *    formProps (see makeFormProps in widget_list.js)
    *    formWrapperProps (defined by custom FormWrapper or _defaultFormWrapper in defaults.js
    */
-  constructor(props) {
-    super(props)
-    this.state = {
-      currentWidgetData: null,
-      widgetClass: null,
-      widgetClassConfiguration: null,
-    }
-    this.onSubmit = this.onSubmit.bind(this)
+  state = {
+    currentWidgetData: null,
+    widgetClass: null,
+    widgetClassConfiguration: null,
   }
 
   componentDidMount() {
@@ -44,7 +40,7 @@ class EditWidgetForm extends Component {
       .catch(errorHandler)
   }
 
-  onSubmit(widgetClass, formData) {
+  onSubmit = (widgetClass, formData) => {
     /**
      * onSubmit is the onClick behavior of the submit button. It parses the title out of the data and makes a PATCH
      *    request to the backend. Then it calls the passed in prop onSubmit
@@ -100,13 +96,9 @@ class NewWidgetForm extends Component {
    *    formProps (see makeFormProps in widget_list.js)
    *    formWrapperProps (defined by custom FormWrapper or _defaultFormWrapper in defaults.js
    */
-  constructor(props) {
-    super(props)
-    this.state = {
-      widgetClassConfigurations: null,
-      widgetClasses: null,
-    }
-    this.onSubmit = this.onSubmit.bind(this)
+  state = {
+    widgetClassConfigurations: null,
+    widgetClasses: null,
   }
 
   componentDidMount() {
@@ -123,7 +115,7 @@ class NewWidgetForm extends Component {
       .catch(errorHandler)
   }
 
-  onSubmit(widgetClass, formData) {
+  onSubmit = (widgetClass, formData) => {
     /**
      * onSubmit is the onClick behavior of the submit button. It parses the title out of the data and makes a POST
      *    request to the backend. Then it calls the passed in prop onSubmit
@@ -182,17 +174,9 @@ class WidgetForm extends Component {
    *    formData: keeps track of the current input of the form
    *    widgetClass: keeps track of the current chosen class
    */
-  constructor(props) {
-    super(props)
-    const { formData, widgetClass } = this.props
-    this.state = {
-      formData: formData,
-      widgetClass: widgetClass,
-    }
-    this.onChange = this.onChange.bind(this)
-    this.onSubmit = this.onSubmit.bind(this)
-    this.makeWidgetClassSelect = this.makeWidgetClassSelect.bind(this)
-    this.renderInputs = this.renderInputs.bind(this)
+  state = {
+    formData: this.props.formData,
+    widgetClass: this.props.widgetClass,
   }
 
   onChange(key, value) {
@@ -208,7 +192,7 @@ class WidgetForm extends Component {
     })
   }
 
-  onSubmit(event) {
+  onSubmit = (event) => {
     /**
      * Submit widget class and form data with onSubmit from props
      */
@@ -219,7 +203,7 @@ class WidgetForm extends Component {
     onSubmit(widgetClass, formData)
   }
 
-  makeWidgetClassSelect() {
+  makeWidgetClassSelect = () => {
     /**
      * makeWidgetClassSelect makes a react-select component
      */
@@ -252,7 +236,7 @@ class WidgetForm extends Component {
     )
   }
 
-  renderInputs(model) {
+  renderInputs = (model) => {
     /**
      * Render widget form inputs based on the configuration of widgetClass
      *

--- a/open-widget-framework/src/widget_list.js
+++ b/open-widget-framework/src/widget_list.js
@@ -28,24 +28,7 @@ class WidgetList extends Component {
 
   static defaultProps = {...defaultSettings}
 
-  constructor(props) {
-    super(props)
-    this.state = {widgetInstances: null}
-    this.loadData = this.loadData.bind(this)
-    this.updateWidgetList = this.updateWidgetList.bind(this)
-    this.moveWidget = this.moveWidget.bind(this)
-    this.deleteWidget = this.deleteWidget.bind(this)
-    this.makePassThroughProps = this.makePassThroughProps.bind(this)
-    this.makeFormProps = this.makeFormProps.bind(this)
-    this.renderWidgetList = this.renderWidgetList.bind(this)
-    this.renderListBody = this.renderListBody.bind(this)
-    this.renderWidget = this.renderWidget.bind(this)
-    this.renderWidgetBody = this.renderWidgetBody.bind(this)
-    this.renderEditWidgetForm = this.renderEditWidgetForm.bind(this)
-    this.renderNewWidgetForm = this.renderNewWidgetForm.bind(this)
-    this.renderEditWidgetFormBody = this.renderEditWidgetFormBody.bind(this)
-    this.renderNewWidgetFormBody = this.renderNewWidgetFormBody.bind(this)
-  }
+  state = {widgetInstances: null}
 
   componentDidMount() {
     /**
@@ -63,7 +46,7 @@ class WidgetList extends Component {
     }
   }
 
-  loadData() {
+  loadData = () => {
     /**
      * loadData fetches the widget instances and runs updateWidgetList
      */
@@ -73,14 +56,14 @@ class WidgetList extends Component {
       .catch(errorHandler)
   }
 
-  updateWidgetList(data) {
+  updateWidgetList = (data) => {
     /**
      * updateWidgetList takes widgetInstances data and sets the state
      */
     this.setState({widgetInstances: data})
   }
 
-  deleteWidget(widgetId) {
+  deleteWidget = (widgetId) => {
     /**
      * Make request to server to delete a widget with id widgetId
      */
@@ -90,7 +73,7 @@ class WidgetList extends Component {
       .catch(errorHandler)
   }
 
-  moveWidget(widgetId, position) {
+  moveWidget = (widgetId, position) => {
     /**
      * Make request to server to move widget with id widgetId to position in the widget-list
      */
@@ -103,7 +86,7 @@ class WidgetList extends Component {
       .catch(errorHandler)
   }
 
-  makePassThroughProps(widgetInstance) {
+  makePassThroughProps = (widgetInstance) => {
     /**
      * makePassThroughProps constructs an object of props to pass to children components. This allows the wrapper
      *    components to have access to various information from the widget-list and ways of manipulating the
@@ -146,7 +129,7 @@ class WidgetList extends Component {
     return passThroughProps
   }
 
-  makeFormProps() {
+  makeFormProps = () => {
     /**
      * makeFormProps constructs an object of props to pass to widget-forms. These are the defaultProps and
      * passThroughProps that are required for handling the widget-forms
@@ -172,7 +155,7 @@ class WidgetList extends Component {
     }
   }
 
-  renderWidgetList() {
+  renderWidgetList = () => {
     /**
      * renders ListWrapper with passThroughProps and any listWrapperProps passed to widget-list.
      *    Will call renderListBody.
@@ -185,7 +168,7 @@ class WidgetList extends Component {
     )
   }
 
-  renderListBody(listWrapperProps) {
+  renderListBody = (listWrapperProps) => {
     /**
      * renders each widget instance
      */
@@ -195,7 +178,7 @@ class WidgetList extends Component {
     )
   }
 
-  renderWidget(widgetInstance, listWrapperProps) {
+  renderWidget = (widgetInstance, listWrapperProps) => {
     /**
      * renders WidgetWrapper with passThroughProps, any widgetWrapperProps passed to widget-list, any listWrapperProps
      *    passed from ListWrapper, and the elements of widgetInstance as props as well. Will call renderWidgetBody.
@@ -211,7 +194,7 @@ class WidgetList extends Component {
     )
   }
 
-  renderWidgetBody(widgetInstance) {
+  renderWidgetBody = (widgetInstance) => {
     /**
      * finds appropriate renderer and render the widget instance
      */
@@ -224,7 +207,7 @@ class WidgetList extends Component {
     )
   }
 
-  renderEditWidgetForm(widgetId, listWrapperProps) {
+  renderEditWidgetForm = (widgetId, listWrapperProps) => {
     /**
      * renders FormWrapper with passThroughProps, any formWrapperProps passed to widget-list, and any listWrapperProps
      *    passed from ListWrapper. Will call renderEditWidgetFormBody
@@ -239,7 +222,7 @@ class WidgetList extends Component {
     )
   }
 
-  renderEditWidgetFormBody(widgetId, formWrapperProps) {
+  renderEditWidgetFormBody = (widgetId, formWrapperProps) => {
     /**
      * renders an EditWidgetForm for widget with widgetId with formProps and any formWrapperProps passed from
      *    FormWrapper
@@ -252,7 +235,7 @@ class WidgetList extends Component {
     )
   }
 
-  renderNewWidgetForm(listWrapperProps) {
+  renderNewWidgetForm = (listWrapperProps) => {
     /**
      * renders FormWrapper with passThroughProps, any formWrapperProps passed to widget-list, and any listWrapperProps
      *    passed from ListWrapper. Will call renderNewWidgetFormBody
@@ -268,7 +251,7 @@ class WidgetList extends Component {
     )
   }
 
-  renderNewWidgetFormBody(formWrapperProps) {
+  renderNewWidgetFormBody = (formWrapperProps) => {
     /**
      * renders an NewWidgetForm with formProps and any formWrapperProps passed from FormWrapper
      */

--- a/open-widget-framework/yarn.lock
+++ b/open-widget-framework/yarn.lock
@@ -235,6 +235,18 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.0.0"
 
+"@babel/plugin-proposal-class-properties@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz#9af01856b1241db60ec8838d84691aa0bd1e8df4"
+  integrity sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+    "@babel/plugin-syntax-class-properties" "^7.0.0"
+
 "@babel/plugin-proposal-json-strings@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz#3b4d7b5cf51e1f2e70f52351d28d44fc2970d01e"
@@ -272,6 +284,13 @@
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz#bf0891dcdbf59558359d0c626fdc9490e20bc13c"
   integrity sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-class-properties@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz#e051af5d300cbfbcec4a7476e37a803489881634"
+  integrity sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
Move react components over to using class properties which eliminates the need for constructors