### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
This file tells certain editors like PyCharm whether to prefer tabs or spaces, what the indentation is, and other configuration settings