### PR TITLE
Added widget framework permission classes setting into views

### DIFF
--- a/open_widget_framework/open_widget_framework/views.py
+++ b/open_widget_framework/open_widget_framework/views.py
@@ -36,6 +36,7 @@ class WidgetListViewSet(ModelViewSet):
     """
     queryset = WidgetList.objects.all()
     serializer_class = WidgetListSerializer
+    permission_classes = (api_settings.WIDGET_FRAMEWORK_PERMISSION_CLASSES,)
 
     @action(detail=False)
     def get_configurations(self, request):


### PR DESCRIPTION
In response to Issue #28 

@rhysyngsun This enables default object level permission checking for widget_list api endpoints. I believe authentication should be handled by default as per your comment in PR #14.